### PR TITLE
Inverse relations closure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 subprojects {
 	group = 'io.opencaesar.adapters'
-	version = '1.4.0'
+	version = '1.4.1'
 	
 	ext.versions = [
 	    oml: '1.+',

--- a/oml2owl/src/main/java/io/opencaesar/oml2owl/CloseDescriptionBundle.java
+++ b/oml2owl/src/main/java/io/opencaesar/oml2owl/CloseDescriptionBundle.java
@@ -659,12 +659,25 @@ public class CloseDescriptionBundle {
 						}
 					});
 				});
+
+				OmlSearch.findRelationInstancesWithTarget(subj).forEach(ri -> {
+					ri.getOwnedTypes().forEach(rta ->{
+						final Relation rel = rta.getType().getReverseRelation();
+						if (all_relations.contains(rel)) {
+							subj_vals_map.get(rel).addAll(ri.getSources());
+						}
+					});
+				});
+
+
 				OmlSearch.findLinkAssertions(subj).forEach(link -> {
 					final Relation rel = link.getRelation();
+					final Relation irel = rel.getInverse();
 					if (all_relations.contains(rel)) {
 						subj_vals_map.get(rel).add(link.getTarget());
+					} else if (all_relations.contains(irel)) {
+						subj_vals_map.get(rel).add(link.getOwningInstance());
 					}
-
 				});
 				OmlSearch.findAllTypes(subj).stream()
 					.filter(r -> r instanceof Entity)


### PR DESCRIPTION
The description bundle closure is incorrect in case we have link assertions involving the inverse of relations like `base:isContainedBy`.

Such links need to be taken into account for computing accurate max cardinality restrictions.

A proper fix should use the reasoner to calculate such restrictions. This PR involves a simple fix that accounts for inverse relation link assertions.
